### PR TITLE
Allow empty keys for recent versions of s3cmd

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,13 +9,6 @@ define s3cmd::config (
 ) {
     include s3cmd::params
 
-    if ($s3key == '') {
-        fail('Please specify s3key to access S3')
-    }
-    if ($s3aid == '') {
-        fail('Please specify s3aid to access S3')
-    }
-
     file { "$path":
         ensure  => present,
         content => template('s3cmd/s3cmd.erb'),


### PR DESCRIPTION
With recent versions of `s3cmd`, the access and secret keys can be blank, in which case `s3cmd` uses the EC2 instance role.

This change allows that in the `s3cfg` file.