### PR TITLE
make os selection work on centos distros

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,7 @@
 class s3cmd::params {
 
-case $::lsbdistid {
-    'Ubuntu','Debian' : {
-        $packages = ['s3cmd','python-magic','python-central']
-    }
-    default: { fail("Unsupported OS: ${::lsbdistid}") }
- }
+
+    $packages = ['s3cmd','python-magic']
+    # ,'python-central'
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,17 @@
 class s3cmd::params {
 
+  case $::operatingsystem {
+    'Ubuntu', 'Debian' : {
+      $packages = ['s3cmd','python-magic', 'python-central' ]
+    }
 
-    $packages = ['s3cmd','python-magic']
-    # ,'python-central'
+    'CentOS', 'Redhat': {
+      $packages = [ 's3cmd','python-magic']
+    }
+
+    default: {
+      fail("Unsupported OS: ${::operatingsystem} ")
+    }
+
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,5 +13,5 @@ class s3cmd::params {
       fail("Unsupported OS: ${::operatingsystem} ")
     }
 
-
+  }
 }


### PR DESCRIPTION
the previous select was too restrictive for non debian distro usage so this adds centos / redhats to the select statement;